### PR TITLE
 Update to CHERI capabilities after exclusion table to uses the orgianl range 

### DIFF
--- a/mark_rts.c
+++ b/mark_rts.c
@@ -14,6 +14,7 @@
  */
 
 #include "private/gc_priv.h"
+#include <cheri/cheric.h>
 
 #if defined(E2K) && !defined(THREADS)
 #  include <alloca.h>
@@ -148,7 +149,7 @@ GC_add_roots_inner(ptr_t b, ptr_t e, GC_bool tmp)
   if (ADDR_GE(b, e)) {
     /* Nothing to do. */
     return;
-  }
+}
 
 #ifdef ANY_MSWIN
   /* Spend the time to ensure that there are no overlapping */
@@ -641,6 +642,16 @@ GC_exclude_static_roots(void *b, void *e)
 STATIC void
 GC_push_conditional_with_exclusions(ptr_t bottom, ptr_t top, GC_bool all)
 {
+#ifdef CHERI_PURECAP
+  ptr_t range = NULL;
+  if (SPANNING_CAPABILITY(bottom, ADDR(bottom), ADDR(top))){
+    range = bottom;
+  }else if (SPANNING_CAPABILITY(top, ADDR(bottom), ADDR(top))){
+    range = top;
+  }else {
+    ABORT("Capability does not span the entire range");
+  }  
+#endif
   while (ADDR_LT(bottom, top)) {
     struct exclusion *next = GC_next_exclusion(bottom);
     ptr_t excl_start = top;
@@ -649,14 +660,22 @@ GC_push_conditional_with_exclusions(ptr_t bottom, ptr_t top, GC_bool all)
       if (ADDR_GE(next->e_start, top)) {
         next = NULL;
       } else {
+#ifdef CHERI_PURECAP
+        excl_start = cheri_setaddress(range, (ptraddr_t)next->e_start);
+#else
         excl_start = next->e_start;
+#endif
       }
     }
     if (ADDR_LT(bottom, excl_start))
       GC_PUSH_CONDITIONAL(bottom, excl_start, all);
     if (NULL == next)
       break;
+#ifdef CHERI_PURECAP
+    bottom = cheri_setaddress(range, (ptraddr_t)next->e_end);
+#else
     bottom = next->e_end;
+#endif
   }
 }
 

--- a/mark_rts.c
+++ b/mark_rts.c
@@ -14,7 +14,6 @@
  */
 
 #include "private/gc_priv.h"
-#include <cheri/cheric.h>
 
 #if defined(E2K) && !defined(THREADS)
 #  include <alloca.h>
@@ -149,7 +148,7 @@ GC_add_roots_inner(ptr_t b, ptr_t e, GC_bool tmp)
   if (ADDR_GE(b, e)) {
     /* Nothing to do. */
     return;
-}
+  }
 
 #ifdef ANY_MSWIN
   /* Spend the time to ensure that there are no overlapping */
@@ -644,14 +643,15 @@ GC_push_conditional_with_exclusions(ptr_t bottom, ptr_t top, GC_bool all)
 {
 #ifdef CHERI_PURECAP
   ptr_t range = NULL;
-  if (SPANNING_CAPABILITY(bottom, ADDR(bottom), ADDR(top))){
+  if (SPANNING_CAPABILITY(bottom, ADDR(bottom), ADDR(top))) {
     range = bottom;
-  }else if (SPANNING_CAPABILITY(top, ADDR(bottom), ADDR(top))){
+  } else if (SPANNING_CAPABILITY(top, ADDR(bottom), ADDR(top))) {
     range = top;
-  }else {
+  } else {
     ABORT("Capability does not span the entire range");
-  }  
+  }
 #endif
+
   while (ADDR_LT(bottom, top)) {
     struct exclusion *next = GC_next_exclusion(bottom);
     ptr_t excl_start = top;
@@ -661,7 +661,7 @@ GC_push_conditional_with_exclusions(ptr_t bottom, ptr_t top, GC_bool all)
         next = NULL;
       } else {
 #ifdef CHERI_PURECAP
-        excl_start = cheri_setaddress(range, (ptraddr_t)next->e_start);
+        excl_start = cheri_address_set(range, (ptraddr_t)next->e_start);
 #else
         excl_start = next->e_start;
 #endif
@@ -672,7 +672,7 @@ GC_push_conditional_with_exclusions(ptr_t bottom, ptr_t top, GC_bool all)
     if (NULL == next)
       break;
 #ifdef CHERI_PURECAP
-    bottom = cheri_setaddress(range, (ptraddr_t)next->e_end);
+    bottom = cheri_address_set(range, (ptraddr_t)next->e_end);
 #else
     bottom = next->e_end;
 #endif


### PR DESCRIPTION
The issue was that the exclusion table was using the capabilities of the excluded area, which caused the garbage collector to incorrectly handle memory ranges after excluded areas. When pushing memory areas to mark, the region following an excluded area was being skipped entirely due to incorrect capability handling.

The fix ensures proper capability management by:
    Using a spanning capability that covers the entire range (bottom to top)
    Setting addresses on this spanning capability instead of using the exclusion's native capabilities
    Maintaining proper address arithmetic throughout the exclusion processing